### PR TITLE
Migrate to log/slog with structured logging

### DIFF
--- a/raus.go
+++ b/raus.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/redis/go-redis/v9"
 	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 )
 
 type Raus struct {
@@ -44,7 +44,6 @@ var (
 	defaultLogger    = slog.New(slog.NewTextHandler(os.Stderr, nil))
 )
 
-
 type fatal interface {
 	isFatal() bool
 }
@@ -61,8 +60,6 @@ type fatalError struct {
 func (e fatalError) isFatal() bool {
 	return true
 }
-
-
 
 // SetDefaultSlogLogger sets the default slog.Logger for new Raus instances.
 func SetDefaultSlogLogger(l *slog.Logger) {

--- a/raus.go
+++ b/raus.go
@@ -5,7 +5,6 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
-	stdlog "log"
 	"log/slog"
 	"math/rand"
 	"net"
@@ -42,14 +41,9 @@ var (
 	LockExpires      = 60 * time.Second
 	SubscribeTimeout = time.Second * 3
 	CleanupTimeout   = time.Second * 30
-	log              Logger
 	defaultLogger    = slog.New(slog.NewTextHandler(os.Stderr, nil))
 )
 
-type Logger interface {
-	Println(...interface{})
-	Printf(string, ...interface{})
-}
 
 type fatal interface {
 	isFatal() bool
@@ -68,13 +62,7 @@ func (e fatalError) isFatal() bool {
 	return true
 }
 
-func init() {
-	log = stdlog.New(os.Stderr, "", stdlog.LstdFlags) // default logger
-}
 
-func SetLogger(l Logger) {
-	log = l
-}
 
 // SetDefaultSlogLogger sets the default slog.Logger for new Raus instances.
 func SetDefaultSlogLogger(l *slog.Logger) {

--- a/slog_test.go
+++ b/slog_test.go
@@ -1,0 +1,139 @@
+package raus_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/fujiwara/raus"
+)
+
+func TestSlogIntegration(t *testing.T) {
+	// Create a buffer to capture log output
+	var buf bytes.Buffer
+	
+	// Create JSON handler for structured logging
+	handler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+	logger := slog.New(handler)
+	
+	// Set default logger
+	raus.SetDefaultSlogLogger(logger)
+	
+	// Create raus instance
+	r, err := raus.New(redisURL, 0, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	// Test instance-specific logger
+	var instanceBuf bytes.Buffer
+	instanceHandler := slog.NewJSONHandler(&instanceBuf, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})
+	instanceLogger := slog.New(instanceHandler)
+	r.SetSlogLogger(instanceLogger)
+	
+	// Get machine ID
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	
+	machineID, errCh, err := r.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	// Verify machine ID is valid
+	if machineID > 3 {
+		t.Errorf("Invalid machine ID: %d", machineID)
+	}
+	
+	// Let it run for a moment to generate logs
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	
+	// Wait for error channel to close
+	select {
+	case <-errCh:
+	case <-time.After(5 * time.Second):
+	}
+	
+	// Verify structured logs were generated
+	output := instanceBuf.String()
+	if output == "" {
+		t.Error("No log output generated")
+	}
+	
+	// Parse JSON logs to verify structure
+	lines := bytes.Split(instanceBuf.Bytes(), []byte("\n"))
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		
+		var logEntry map[string]interface{}
+		if err := json.Unmarshal(line, &logEntry); err != nil {
+			t.Errorf("Failed to parse JSON log: %v", err)
+			continue
+		}
+		
+		// Verify required fields exist
+		if _, ok := logEntry["time"]; !ok {
+			t.Error("Missing 'time' field in log entry")
+		}
+		if _, ok := logEntry["level"]; !ok {
+			t.Error("Missing 'level' field in log entry")
+		}
+		if _, ok := logEntry["msg"]; !ok {
+			t.Error("Missing 'msg' field in log entry")
+		}
+	}
+	
+	t.Logf("Generated %d log entries with structured logging", len(lines)-1)
+}
+
+func TestBackwardCompatibility(t *testing.T) {
+	// Test that old Logger interface still works
+	originalLogger := &testLogger{}
+	raus.SetLogger(originalLogger)
+	
+	r, err := raus.New(redisURL, 0, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	// The instance should still have a valid slog logger
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	
+	machineID, errCh, err := r.Get(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	
+	if machineID > 3 {
+		t.Errorf("Invalid machine ID: %d", machineID)
+	}
+	
+	cancel()
+	select {
+	case <-errCh:
+	case <-time.After(2 * time.Second):
+	}
+}
+
+type testLogger struct {
+	messages []string
+}
+
+func (l *testLogger) Println(v ...interface{}) {
+	// Implementation not needed for this test
+}
+
+func (l *testLogger) Printf(format string, v ...interface{}) {
+	// Implementation not needed for this test
+}

--- a/slog_test.go
+++ b/slog_test.go
@@ -14,22 +14,22 @@ import (
 func TestSlogIntegration(t *testing.T) {
 	// Create a buffer to capture log output
 	var buf bytes.Buffer
-	
+
 	// Create JSON handler for structured logging
 	handler := slog.NewJSONHandler(&buf, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	})
 	logger := slog.New(handler)
-	
+
 	// Set default logger
 	raus.SetDefaultSlogLogger(logger)
-	
+
 	// Create raus instance
 	r, err := raus.New(redisURL, 0, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
-	
+
 	// Test instance-specific logger
 	var instanceBuf bytes.Buffer
 	instanceHandler := slog.NewJSONHandler(&instanceBuf, &slog.HandlerOptions{
@@ -37,50 +37,50 @@ func TestSlogIntegration(t *testing.T) {
 	})
 	instanceLogger := slog.New(instanceHandler)
 	r.SetSlogLogger(instanceLogger)
-	
+
 	// Get machine ID
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	
+
 	machineID, errCh, err := r.Get(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	
+
 	// Verify machine ID is valid
 	if machineID > 3 {
 		t.Errorf("Invalid machine ID: %d", machineID)
 	}
-	
+
 	// Let it run for a moment to generate logs
 	time.Sleep(100 * time.Millisecond)
 	cancel()
-	
+
 	// Wait for error channel to close
 	select {
 	case <-errCh:
 	case <-time.After(5 * time.Second):
 	}
-	
+
 	// Verify structured logs were generated
 	output := instanceBuf.String()
 	if output == "" {
 		t.Error("No log output generated")
 	}
-	
+
 	// Parse JSON logs to verify structure
 	lines := bytes.Split(instanceBuf.Bytes(), []byte("\n"))
 	for _, line := range lines {
 		if len(line) == 0 {
 			continue
 		}
-		
+
 		var logEntry map[string]interface{}
 		if err := json.Unmarshal(line, &logEntry); err != nil {
 			t.Errorf("Failed to parse JSON log: %v", err)
 			continue
 		}
-		
+
 		// Verify required fields exist
 		if _, ok := logEntry["time"]; !ok {
 			t.Error("Missing 'time' field in log entry")
@@ -92,7 +92,7 @@ func TestSlogIntegration(t *testing.T) {
 			t.Error("Missing 'msg' field in log entry")
 		}
 	}
-	
+
 	t.Logf("Generated %d log entries with structured logging", len(lines)-1)
 }
 
@@ -103,33 +103,33 @@ func TestDefaultSlogLogger(t *testing.T) {
 		Level: slog.LevelInfo,
 	})
 	customLogger := slog.New(handler)
-	
+
 	// Set global default
 	raus.SetDefaultSlogLogger(customLogger)
-	
+
 	r, err := raus.New(redisURL, 0, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
-	
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	
+
 	machineID, errCh, err := r.Get(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	
+
 	if machineID > 3 {
 		t.Errorf("Invalid machine ID: %d", machineID)
 	}
-	
+
 	cancel()
 	select {
 	case <-errCh:
 	case <-time.After(2 * time.Second):
 	}
-	
+
 	// Verify logs were written to our custom logger
 	output := buf.String()
 	if output == "" {


### PR DESCRIPTION
## Summary
Replace standard log with log/slog for structured logging.

## Breaking Changes
- Remove `Logger` interface and `SetLogger()` function
- Add `SetDefaultSlogLogger()` and `SetSlogLogger()` methods

## Migration
```go
// Before
raus.SetLogger(logger)

// After  
raus.SetDefaultSlogLogger(slogLogger)
```

🤖 Generated with [Claude Code](https://claude.ai/code)